### PR TITLE
chore: promote python06 to version 0.0.1 in Staging environment

### DIFF
--- a/config-root/namespaces/jx-staging/python06/python06-0.0.1-release.yaml
+++ b/config-root/namespaces/jx-staging/python06/python06-0.0.1-release.yaml
@@ -1,0 +1,49 @@
+# Source: python06/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2020-12-11T11:27:08Z"
+  deletionTimestamp: null
+  name: 'python06-0.0.1'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.1
+      sha: a111def1c973e695a34647873ac73517ab91a479
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 6177131e62013f992667120ee94e334329f87000
+    - author:
+        email: keefan2667@gmain.com
+        name: keefans
+      branch: master
+      committer:
+        email: keefan2667@gmain.com
+        name: keefans
+      message: |
+        chore: Jenkins X build pack
+      sha: 502b10371376fb5536715aba3d2b47d75c241329
+  gitHttpUrl: https://github.com/keefans/python06
+  gitOwner: keefans
+  gitRepository: python06
+  name: 'python06'
+  releaseNotesURL: https://github.com/keefans/python06/releases/tag/v0.0.1
+  version: v0.0.1
+status: {}

--- a/config-root/namespaces/jx-staging/python06/python06-ingress.yaml
+++ b/config-root/namespaces/jx-staging/python06/python06-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: python06/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: python06
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: python06
+              servicePort: 80
+      host: python06-jx-staging.jx3.sky-cloud.net

--- a/config-root/namespaces/jx-staging/python06/python06-python06-deploy.yaml
+++ b/config-root/namespaces/jx-staging/python06/python06-python06-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: python06/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: python06-python06
+  labels:
+    draft: draft-app
+    chart: "python06-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: python06-python06
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: python06-python06
+    spec:
+      serviceAccountName: python06-python06
+      containers:
+        - name: python06
+          image: "ghcr.io/keefans/python06:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/python06/python06-python06-sa.yaml
+++ b/config-root/namespaces/jx-staging/python06/python06-python06-sa.yaml
@@ -1,0 +1,8 @@
+# Source: python06/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: python06-python06
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/python06/python06-svc.yaml
+++ b/config-root/namespaces/jx-staging/python06/python06-svc.yaml
@@ -1,0 +1,21 @@
+# Source: python06/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: python06
+  labels:
+    chart: "python06-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: python06-python06

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,7 +1,13 @@
 filepath: ""
 helmfiles:
 - path: helmfiles/jx/helmfile.yaml
+  environment: {}
 - path: helmfiles/nginx/helmfile.yaml
+  environment: {}
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+  environment: {}
+- path: helmfiles/jx-staging/helmfile.yaml
+  environment: {}
 templates: {}
+missingFileHandler: ""
 renderedvalues: {}

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -1,13 +1,8 @@
 filepath: ""
 helmfiles:
 - path: helmfiles/jx/helmfile.yaml
-  environment: {}
 - path: helmfiles/nginx/helmfile.yaml
-  environment: {}
 - path: helmfiles/tekton-pipelines/helmfile.yaml
-  environment: {}
 - path: helmfiles/jx-staging/helmfile.yaml
-  environment: {}
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: jx-staging
 repositories:
 - name: dev
@@ -7,8 +11,7 @@ releases:
 - chart: dev/python06
   version: 0.0.1
   name: python06
-  forceNamespace: ""
-  skipDeps: null
+  values:
+  - jx-values.yaml
 templates: {}
-missingFileHandler: ""
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -1,0 +1,14 @@
+filepath: ""
+namespace: jx-staging
+repositories:
+- name: dev
+  url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+releases:
+- chart: dev/python06
+  version: 0.0.1
+  name: python06
+  forceNamespace: ""
+  skipDeps: null
+templates: {}
+missingFileHandler: ""
+renderedvalues: {}

--- a/helmfiles/jx-staging/jx-values.yaml
+++ b/helmfiles/jx-staging/jx-values.yaml
@@ -1,0 +1,53 @@
+jx:
+  imagePullSecrets:
+  - tekton-container-registry-auth
+  secrets:
+    adminUser:
+      password: todo
+      username: todo
+    hmacToken: todo
+    pipelineUser:
+      email: jenkins-x@googlegroups.com
+      token: todo
+      username: jenkins-x-labs-bot
+jxRequirements:
+  autoUpdate:
+    enabled: false
+    schedule: ""
+  cluster:
+    chartRepository: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+    clusterName: kind
+    devEnvApprovers:
+    - todo
+    environmentGitOwner: todo
+    gitKind: github
+    gitName: github
+    gitServer: https://github.com
+    provider: kubernetes
+    registry: ghcr.io
+  environments:
+  - key: dev
+    owner: keefans
+    repository: jx3-k8s-template
+  - key: staging
+  - key: production
+  ingress:
+    domain: jx3.sky-cloud.net
+    externalDNS: false
+    namespaceSubDomain: -jx-staging.
+    tls:
+      email: ""
+      enabled: false
+      production: false
+  pipelineUser:
+    username: keefans
+  repository: bucketrepo
+  secretStorage: local
+  vault: {}
+  webhook: lighthouse
+jxRequirementsIngressExternalDNS:
+  enabled: false
+jxRequirementsIngressTLS:
+  enabled: false
+jxRequirementsVault:
+  enabled: false


### PR DESCRIPTION
chore: promote python06 to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge